### PR TITLE
add html language and aria-hidden equals true

### DIFF
--- a/_includes/link.html
+++ b/_includes/link.html
@@ -11,7 +11,7 @@
   {%- comment -%} icon and title must be next to each other without whitespace {%- endcomment -%}
 
   {% if include.icon %}
-    {% capture icon %}<i class="icon {{ include.icon }}" aria-hidden></i>{% endcapture %}
+    {% capture icon %}<i class="icon {{ include.icon }}" aria-hidden="true"></i>{% endcapture %}
   {% endif %}
 
   {% if include.hide_title == true %}

--- a/_includes/syndication-link.html
+++ b/_includes/syndication-link.html
@@ -1,7 +1,7 @@
 <li class="link {{ include.class }} {{ include.title | slugify }} {% unless include.title %}no-title{% endunless %} {% unless include.icon %}no-icon{% endunless %}">
   <a class="u-syndication" href="{{ include.url }}">
     {% if include.icon %}
-      <i class="{{ include.icon }}" aria-hidden></i>
+      <i class="{{ include.icon }}" aria-hidden="true"></i>
     {% endif %}
     <span class="title">{{ include.title }}</span>
   </a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,7 +26,7 @@
 {% endif %}
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   {% if jekyll.environment == "production" %}
   <!-- Global site tag (gtag.js) - Google Analytics -->


### PR DESCRIPTION
the language hadn't been set, and apparently, if the aria-hidden
attribute is used, it has to explicitly be set to true.

**before commit**
![before commit](https://user-images.githubusercontent.com/5070516/78931984-a8954e00-7a9e-11ea-9510-be645bcde87e.png)

**after commit**
![after commit](https://user-images.githubusercontent.com/5070516/78932009-b21eb600-7a9e-11ea-9568-84819a771fc6.png)
